### PR TITLE
Create And Load Buffer If It Doesn't Exist.

### DIFF
--- a/lua/bunnyhop/init.lua
+++ b/lua/bunnyhop/init.lua
@@ -178,7 +178,8 @@ local function extract_pred(llm_output)
         if #pred.file == 0 or vim.fn.filereadable(pred.file) == 0 then
             pred.file = globals.DEFAULT_CURSOR_PRED_FILE
         end
-        local pred_buf_num = vim.fn.bufnr(pred.file, true)
+        local pred_buf_num = vim.fn.bufadd(pred.file)
+        vim.fn.bufload(pred_buf_num)
 
         pred.line = pred_str[1]
         if type(pred.line) ~= "number" then


### PR DESCRIPTION
This was made to solve issue #21. It fixes the case of Neovim can't open file if it doesn't have a buffer of the file loaded.